### PR TITLE
Фикс для самоотписывающихся обработчиков

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,9 @@
 
     window.addEventListener('VKWebAppEvent', function() {
       var args = Array.prototype.slice.call(arguments);
+      var _subscribers = subscribers.slice();
 
-      subscribers.forEach(function(fn) {
+      _subscribers.forEach(function(fn) {
         fn.apply(null, args);
       });
     });


### PR DESCRIPTION
Если обработчик события отписывал сам себя, то длина списка обработчиков уменьшалась, и пропускался обработчик, следующий за тем, что отписался. Теперь создается копия списка обработчиков и используется она, чтобы такого не происходило.